### PR TITLE
Clarify error message to warning message in notebook

### DIFF
--- a/book/llms/debugging-errors.ipynb
+++ b/book/llms/debugging-errors.ipynb
@@ -69,7 +69,7 @@
     "\n",
     "The below Python snippet is meant to plot a list of numbers after taking their inverse, however, it fails for a certain value. It still produces a (mostly correct) plot, but the error is visible in the console. Run the code below to see the error message, then copy and paste it into the LLM to get a fixed version.\n",
     "\n",
-    "You will see an error message similar to:\n",
+    "You will see an warning message similar to (please note that this warning might not show up in 'live code mode' in the online book):\n",
     "\n",
     "```\n",
     "RuntimeWarning: divide by zero encountered in divide\n",


### PR DESCRIPTION
Updated the error message description to specify that a warning might occur instead of an error.